### PR TITLE
refactor: remove SSE dependency

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -10,7 +10,6 @@
     "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.2.3",
     "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.5.0",
-    "sse.js": "https://esm.sh/sse.js@0.6.1",
     "std/": "https://deno.land/std@0.182.0/",
     "twind": "https://esm.sh/twind@0.16.19",
     "twind/": "https://esm.sh/twind@0.16.19/"

--- a/routes/api/vector-search.ts
+++ b/routes/api/vector-search.ts
@@ -40,13 +40,7 @@ export const handler = async (
       );
     }
 
-    const requestData = await req.json();
-
-    if (!requestData) {
-      throw new UserError("Missing request data");
-    }
-
-    const { query } = requestData;
+    const query = new URL(req.url).searchParams.get("query");
 
     if (!query) {
       throw new UserError("Missing query in request data");


### PR DESCRIPTION
Instead, the [`EventSource` interface](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) is used. As stated in [the README for sse.js](https://github.com/mpetazzoni/sse.js), the main limitations of `EventSource` are that it only supports no-payload GET requests and does not support specifying additional custom headers to the HTTP request. Hence, the `/api/vector-search` route was modified to get search data from the `query` parameter instead of the body.
