### PR TITLE
refactor: improve input element ergonomics

### DIFF
--- a/islands/SearchDialog.tsx
+++ b/islands/SearchDialog.tsx
@@ -60,7 +60,6 @@ export default function SearchDialog() {
         <form onSubmit={onSubmit}>
           <input
             name="search"
-            value={search}
             ref={inputRef}
             placeholder="Search"
             disabled={!IS_BROWSER}

--- a/islands/SearchDialog.tsx
+++ b/islands/SearchDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useRef, useState } from "preact/hooks";
 import { IS_BROWSER } from "$fresh/runtime.ts";
 import { Button } from "../components/Button.tsx";
 import { SSE } from "sse.js";
@@ -9,9 +9,12 @@ export default function SearchDialog() {
   const [isLoading, setIsLoading] = useState(false);
   const [answer, setAnswer] = useState<string>("");
 
+  const inputRef = useRef<HTMLInputElement>(null);
+
   // @ts-ignore TODO: how to type this?
   const onSubmit = (e) => {
     e.preventDefault();
+    setSearch(inputRef.current!.value);
     console.log(search);
     setAnswer("");
     setIsLoading(true);
@@ -59,7 +62,7 @@ export default function SearchDialog() {
             name="search"
             value={search}
             // @ts-ignore not sure why complaing
-            onInput={(e) => setSearch(e.target?.value ?? "")}
+            ref={inputRef}
             placeholder="Search"
             disabled={!IS_BROWSER}
             class={`px-3 py-2 bg-white rounded border(gray-500 2) disabled:(opacity-50 cursor-not-allowed)`}

--- a/islands/SearchDialog.tsx
+++ b/islands/SearchDialog.tsx
@@ -61,7 +61,6 @@ export default function SearchDialog() {
           <input
             name="search"
             value={search}
-            // @ts-ignore not sure why complaing
             ref={inputRef}
             placeholder="Search"
             disabled={!IS_BROWSER}


### PR DESCRIPTION
Now, `setSearch()` only runs once at the beginning of the form's `onSubmit` event instead of every keystroke. The `value` element is also removed, as it appears to be unneeded.