### PR TITLE
refactor: improve `/api/vector-search` structure

### DIFF
--- a/routes/api/vector-search.ts
+++ b/routes/api/vector-search.ts
@@ -1,4 +1,3 @@
-import { HandlerContext } from "$fresh/server.ts";
 import "https://deno.land/x/xhr@0.2.1/mod.ts";
 import { createClient } from "@supabase/supabase-js";
 import { codeBlock, oneLine } from "commmon-tags";
@@ -10,34 +9,35 @@ const openAiKey = Deno.env.get("OPENAI_KEY");
 const supabaseUrl = Deno.env.get("SUPABASE_URL");
 const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 
+if (!openAiKey) {
+  throw new ApplicationError("Missing environment variable OPENAI_KEY");
+}
+
+if (!supabaseUrl) {
+  throw new ApplicationError("Missing environment variable SUPABASE_URL");
+}
+
+if (!supabaseServiceKey) {
+  throw new ApplicationError(
+    "Missing environment variable SUPABASE_SERVICE_ROLE_KEY",
+  );
+}
+
+const supabaseClient = createClient(supabaseUrl, supabaseServiceKey);
+const openAiConfiguration = new Configuration({ apiKey: openAiKey });
+const openai = new OpenAIApi(openAiConfiguration);
+
 export const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":
     "authorization, x-client-info, apikey, content-type",
 };
 
-export const handler = async (
-  req: Request,
-  _ctx: HandlerContext,
-): Promise<Response> => {
+export async function handler(req: Request): Promise<Response> {
   try {
     // Handle CORS
     if (req.method === "OPTIONS") {
       return new Response("ok", { headers: corsHeaders });
-    }
-
-    if (!openAiKey) {
-      throw new ApplicationError("Missing environment variable OPENAI_KEY");
-    }
-
-    if (!supabaseUrl) {
-      throw new ApplicationError("Missing environment variable SUPABASE_URL");
-    }
-
-    if (!supabaseServiceKey) {
-      throw new ApplicationError(
-        "Missing environment variable SUPABASE_SERVICE_ROLE_KEY",
-      );
     }
 
     const requestData = await req.json();
@@ -53,11 +53,6 @@ export const handler = async (
     }
 
     const sanitizedQuery = query.trim();
-
-    const supabaseClient = createClient(supabaseUrl, supabaseServiceKey);
-
-    const configuration = new Configuration({ apiKey: openAiKey });
-    const openai = new OpenAIApi(configuration);
 
     // Moderate the content to comply with OpenAI T&C
     const moderationResponse = await openai.createModeration({
@@ -105,8 +100,7 @@ export const handler = async (
     let tokenCount = 0;
     let contextText = "";
 
-    for (let i = 0; i < pageSections.length; i++) {
-      const pageSection = pageSections[i];
+    for (const pageSection of pageSections) {
       const content = pageSection.content;
       const encoded = tokenizer.encode(content);
       tokenCount += encoded.text.length;
@@ -146,6 +140,7 @@ export const handler = async (
       stream: true,
     };
 
+    // The Fetch API allows for easier response streaming over the OpenAI client.
     const response = await fetch("https://api.openai.com/v1/completions", {
       headers: {
         Authorization: `Bearer ${openAiKey}`,
@@ -192,4 +187,4 @@ export const handler = async (
       headers: corsHeaders,
     });
   }
-};
+}


### PR DESCRIPTION
1. Moves code that doesn't depend on the handler to outside of the handler. This code now only runs once instead of on each request.
2. Removes the declaration of the `_ctx` parameter, which isn't used.
3. Adds a small explainer as to why `fetch()` is used instead of the OpenAI client.
4. Stylistic improvements (IMO): `handler()` to normal function and using a for-in loop instead of a regular for loop.