### PR TITLE
refactor: use `throwOnError()`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Use Unix line endings in all text files.
+* text=auto eol=lf

--- a/tools/generate-embeddings.ts
+++ b/tools/generate-embeddings.ts
@@ -381,7 +381,7 @@ async function generateEmbeddings() {
           .from("dfods_page_section")
           .delete()
           .filter("page_id", "eq", existingPage.id)
-          .throwOnError;
+          .throwOnError();
       }
 
       const { data: parentPage } = await supabaseClient

--- a/tools/generate-embeddings.ts
+++ b/tools/generate-embeddings.ts
@@ -334,16 +334,13 @@ async function generateEmbeddings() {
       const { checksum, meta, sections } = await embeddingSource.load();
 
       // Check for existing page in DB and compare checksums
-      const { error: fetchPageError, data: existingPage } = await supabaseClient
+      const { data: existingPage } = await supabaseClient
         .from("dfods_page")
         .select("id, path, checksum, parentPage:parent_page_id(id, path)")
         .filter("path", "eq", path)
         .limit(1)
-        .maybeSingle();
-
-      if (fetchPageError) {
-        throw fetchPageError;
-      }
+        .maybeSingle()
+        .throwOnError();
 
       type Singular<T> = T extends any[] ? undefined : T;
 
@@ -358,26 +355,19 @@ async function generateEmbeddings() {
           console.log(
             `[${path}] Parent page has changed. Updating to '${parentPath}'...`,
           );
-          const { error: fetchParentPageError, data: parentPage } =
-            await supabaseClient
+          const { data: parentPage } = await supabaseClient
               .from("dfods_page")
               .select()
               .filter("path", "eq", parentPath)
               .limit(1)
-              .maybeSingle();
+              .maybeSingle()
+              .throwOnError();
 
-          if (fetchParentPageError) {
-            throw fetchParentPageError;
-          }
-
-          const { error: updatePageError } = await supabaseClient
+          await supabaseClient
             .from("dfods_page")
             .update({ parent_page_id: parentPage?.id })
-            .filter("id", "eq", existingPage.id);
-
-          if (updatePageError) {
-            throw updatePageError;
-          }
+            .filter("id", "eq", existingPage.id)
+            .throwOnError();
         }
         continue;
       }
@@ -387,31 +377,24 @@ async function generateEmbeddings() {
           `[${path}] Docs have changed, removing old page sections and their embeddings`,
         );
 
-        const { error: deletePageSectionError } = await supabaseClient
+        await supabaseClient
           .from("dfods_page_section")
           .delete()
-          .filter("page_id", "eq", existingPage.id);
-
-        if (deletePageSectionError) {
-          throw deletePageSectionError;
-        }
+          .filter("page_id", "eq", existingPage.id)
+          .throwOnError;
       }
 
-      const { error: fetchParentPageError, data: parentPage } =
-        await supabaseClient
+      const { data: parentPage } = await supabaseClient
           .from("dfods_page")
           .select()
           .filter("path", "eq", parentPath)
           .limit(1)
-          .maybeSingle();
-
-      if (fetchParentPageError) {
-        throw fetchParentPageError;
-      }
+          .maybeSingle()
+          .throwOnError();
 
       // Create/update page record. Intentionally clear checksum until we
       // have successfully generated all page sections.
-      const { error: upsertPageError, data: page } = await supabaseClient
+      const { data: page } = await supabaseClient
         .from("dfods_page")
         .upsert(
           {
@@ -426,11 +409,8 @@ async function generateEmbeddings() {
         )
         .select()
         .limit(1)
-        .single();
-
-      if (upsertPageError) {
-        throw upsertPageError;
-      }
+        .single()
+        .throwOnError();
 
       console.log(
         `[${path}] Adding ${sections.length} page sections (with embeddings)`,
@@ -461,8 +441,7 @@ async function generateEmbeddings() {
 
           const [responseData] = embeddingResponse.data.data;
 
-          const { error: insertPageSectionError, data: pageSection } =
-            await supabaseClient
+          await supabaseClient
               .from("dfods_page_section")
               .insert({
                 page_id: page.id,
@@ -474,11 +453,8 @@ async function generateEmbeddings() {
               })
               .select()
               .limit(1)
-              .single();
-
-          if (insertPageSectionError) {
-            throw insertPageSectionError;
-          }
+              .single()
+              .throwOnError();
         } catch (err) {
           // TODO: decide how to better handle failed embeddings
           console.error(
@@ -495,14 +471,11 @@ async function generateEmbeddings() {
       }
 
       // Set page checksum so that we know this page was stored successfully
-      const { error: updatePageError } = await supabaseClient
+      await supabaseClient
         .from("dfods_page")
         .update({ checksum })
-        .filter("id", "eq", page.id);
-
-      if (updatePageError) {
-        throw updatePageError;
-      }
+        .filter("id", "eq", page.id)
+        .throwOnError();
     } catch (err) {
       console.error(
         `Page '${path}' or one/multiple of its page sections failed to store properly. Page has been marked with null checksum to indicate that it needs to be re-generated.`,

--- a/tools/generate-embeddings.ts
+++ b/tools/generate-embeddings.ts
@@ -356,12 +356,12 @@ async function generateEmbeddings() {
             `[${path}] Parent page has changed. Updating to '${parentPath}'...`,
           );
           const { data: parentPage } = await supabaseClient
-              .from("dfods_page")
-              .select()
-              .filter("path", "eq", parentPath)
-              .limit(1)
-              .maybeSingle()
-              .throwOnError();
+            .from("dfods_page")
+            .select()
+            .filter("path", "eq", parentPath)
+            .limit(1)
+            .maybeSingle()
+            .throwOnError();
 
           await supabaseClient
             .from("dfods_page")
@@ -385,12 +385,12 @@ async function generateEmbeddings() {
       }
 
       const { data: parentPage } = await supabaseClient
-          .from("dfods_page")
-          .select()
-          .filter("path", "eq", parentPath)
-          .limit(1)
-          .maybeSingle()
-          .throwOnError();
+        .from("dfods_page")
+        .select()
+        .filter("path", "eq", parentPath)
+        .limit(1)
+        .maybeSingle()
+        .throwOnError();
 
       // Create/update page record. Intentionally clear checksum until we
       // have successfully generated all page sections.
@@ -442,19 +442,19 @@ async function generateEmbeddings() {
           const [responseData] = embeddingResponse.data.data;
 
           await supabaseClient
-              .from("dfods_page_section")
-              .insert({
-                page_id: page.id,
-                slug,
-                heading,
-                content,
-                token_count: embeddingResponse.data.usage.total_tokens,
-                embedding: responseData.embedding,
-              })
-              .select()
-              .limit(1)
-              .single()
-              .throwOnError();
+            .from("dfods_page_section")
+            .insert({
+              page_id: page.id,
+              slug,
+              heading,
+              content,
+              token_count: embeddingResponse.data.usage.total_tokens,
+              embedding: responseData.embedding,
+            })
+            .select()
+            .limit(1)
+            .single()
+            .throwOnError();
         } catch (err) {
           // TODO: decide how to better handle failed embeddings
           console.error(

--- a/tools/generate-embeddings.ts
+++ b/tools/generate-embeddings.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck @todo Fix typings in `extractMetaExport()`
 import "https://deno.land/std@0.182.0/dotenv/load.ts";
 import "https://deno.land/x/xhr@0.2.1/mod.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.5.0";


### PR DESCRIPTION
This reduces the need to throw errors using the returned error object explicitly.