### PR TITLE
feat: Deno Deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # fresh project
 
+[![Deploy this example](https://deno.com/docs/deno-deploy-button.svg)](https://dash.deno.com/new?url=https://raw.githubusercontent.com/supabase-community/deno-fresh-openai-doc-search/main/main.ts&env=OPENAI_KEY,SUPABASE_URL,SUPABASE_SERVICE_ROLE_KEY)
+
 ## Setup
 
 ```bash


### PR DESCRIPTION
Some testing has revealed that the Deno Deploy button may not be compatible with a project using Fresh. This is because Fresh uses import maps, which Deno Deploy doesn't know how to detect and therefore handle. I'll raise an issue with Deno.

Closes #14.