### PR TITLE
feat: root import

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -1,5 +1,6 @@
 {
   "imports": {
+    "@/": "./",
     "$fresh/": "https://deno.land/x/fresh@1.1.5/",
     "commmon-tags": "https://esm.sh/common-tags@1.8.2",
     "gpt3-tokenizer": "https://esm.sh/gpt3-tokenizer@1.1.5",

--- a/islands/SearchDialog.tsx
+++ b/islands/SearchDialog.tsx
@@ -1,7 +1,7 @@
 import { useSignal } from "@preact/signals";
 import { useRef } from "preact/hooks";
 import { IS_BROWSER } from "$fresh/runtime.ts";
-import { Button } from "../components/Button.tsx";
+import { Button } from "@/components/Button.tsx";
 import type { CreateCompletionResponse } from "openai";
 
 export default function SearchDialog() {

--- a/routes/api/vector-search.ts
+++ b/routes/api/vector-search.ts
@@ -3,7 +3,7 @@ import { createClient } from "@supabase/supabase-js";
 import { codeBlock, oneLine } from "commmon-tags";
 import GPT3Tokenizer from "gpt3-tokenizer";
 import { Configuration, CreateCompletionRequest, OpenAIApi } from "openai";
-import { ApplicationError, UserError } from "../../utils/errors.ts";
+import { ApplicationError, UserError } from "@/utils/errors.ts";
 
 const openAiKey = Deno.env.get("OPENAI_KEY");
 const supabaseUrl = Deno.env.get("SUPABASE_URL");

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,5 +1,5 @@
 import { Head } from "$fresh/runtime.ts";
-import SearchDialog from "../islands/SearchDialog.tsx";
+import SearchDialog from "@/islands/SearchDialog.tsx";
 
 export default function Home() {
   return (


### PR DESCRIPTION
Knowing where an import is relative to the root of the codebase is more straightforward than knowing where an import is relative to the current file. This is also useful when moving files, as the imports don't have to be adjusted.